### PR TITLE
fix: support legacy Twitter env vars

### DIFF
--- a/apps/frontend/src/components/launches/add.provider.component.tsx
+++ b/apps/frontend/src/components/launches/add.provider.component.tsx
@@ -359,14 +359,20 @@ export const AddProviderComponent: FC<{
           return;
         };
         const gotoIntegration = async (externalUrl?: string) => {
+          const endpoint =
+            identifier === 'x'
+              ? `/integrations/social/${identifier}/connect`
+              : `/integrations/social/${identifier}${
+                  externalUrl ? `?externalUrl=${externalUrl}` : ``
+                }`;
+          const options =
+            identifier === 'x'
+              ? { method: 'POST' as const }
+              : undefined;
           const { url, err } = await (
-            await fetch(
-              `/integrations/social/${identifier}${
-                externalUrl ? `?externalUrl=${externalUrl}` : ``
-              }`
-            )
+            await fetch(endpoint, options)
           ).json();
-          if (err) {
+          if (err || !url) {
             toaster.show('Could not connect to the platform', 'warning');
             return;
           }

--- a/apps/frontend/src/components/onboarding/connect.channels.tsx
+++ b/apps/frontend/src/components/onboarding/connect.channels.tsx
@@ -117,14 +117,20 @@ export const ConnectChannels: FC = () => {
       ) =>
       async () => {
         const gotoIntegration = async (externalUrl?: string) => {
+          const endpoint =
+            identifier === 'x'
+              ? `/integrations/social/${identifier}/connect`
+              : `/integrations/social/${identifier}${
+                  externalUrl ? `?externalUrl=${externalUrl}` : ``
+                }`;
+          const options =
+            identifier === 'x'
+              ? { method: 'POST' as const }
+              : undefined;
           const { url, err } = await (
-            await fetch(
-              `/integrations/social/${identifier}${
-                externalUrl ? `?externalUrl=${externalUrl}` : ``
-              }`
-            )
+            await fetch(endpoint, options)
           ).json();
-          if (err) {
+          if (err || !url) {
             toaster.show('Could not connect to the platform', 'warning');
             return;
           }

--- a/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
+++ b/libraries/nestjs-libraries/src/integrations/social/x.provider.ts
@@ -18,6 +18,9 @@ import dayjs from 'dayjs';
 import { uniqBy } from 'lodash';
 import { stripHtmlValidation } from '@gitroom/helpers/utils/strip.html.validation';
 
+const API_KEY = process.env.X_API_KEY || process.env.TWITTER_API_KEY;
+const API_SECRET = process.env.X_API_SECRET || process.env.TWITTER_API_SECRET;
+
 export class XProvider extends SocialAbstract implements SocialProvider {
   identifier = 'x';
   name = 'X';
@@ -84,8 +87,8 @@ export class XProvider extends SocialAbstract implements SocialProvider {
     // eslint-disable-next-line prefer-rest-params
     const [accessTokenSplit, accessSecretSplit] = integration.token.split(':');
     const client = new TwitterApi({
-      appKey: process.env.X_API_KEY!,
-      appSecret: process.env.X_API_SECRET!,
+      appKey: API_KEY!,
+      appSecret: API_SECRET!,
       accessToken: accessTokenSplit,
       accessSecret: accessSecretSplit,
     });
@@ -117,8 +120,8 @@ export class XProvider extends SocialAbstract implements SocialProvider {
   ) {
     const [accessTokenSplit, accessSecretSplit] = integration.token.split(':');
     const client = new TwitterApi({
-      appKey: process.env.X_API_KEY!,
-      appSecret: process.env.X_API_SECRET!,
+      appKey: API_KEY!,
+      appSecret: API_SECRET!,
       accessToken: accessTokenSplit,
       accessSecret: accessSecretSplit,
     });
@@ -168,8 +171,8 @@ export class XProvider extends SocialAbstract implements SocialProvider {
     // eslint-disable-next-line prefer-rest-params
     const [accessTokenSplit, accessSecretSplit] = integration.token.split(':');
     const client = new TwitterApi({
-      appKey: process.env.X_API_KEY!,
-      appSecret: process.env.X_API_SECRET!,
+      appKey: API_KEY!,
+      appSecret: API_SECRET!,
       accessToken: accessTokenSplit,
       accessSecret: accessSecretSplit,
     });
@@ -204,8 +207,8 @@ export class XProvider extends SocialAbstract implements SocialProvider {
 
   async generateAuthUrl() {
     const client = new TwitterApi({
-      appKey: process.env.X_API_KEY!,
-      appSecret: process.env.X_API_SECRET!,
+      appKey: API_KEY!,
+      appSecret: API_SECRET!,
     });
     const { url, oauth_token, oauth_token_secret } =
       await client.generateAuthLink(
@@ -229,8 +232,8 @@ export class XProvider extends SocialAbstract implements SocialProvider {
     const [oauth_token, oauth_token_secret] = codeVerifier.split(':');
 
     const startingClient = new TwitterApi({
-      appKey: process.env.X_API_KEY!,
-      appSecret: process.env.X_API_SECRET!,
+      appKey: API_KEY!,
+      appSecret: API_SECRET!,
       accessToken: oauth_token,
       accessSecret: oauth_token_secret,
     });
@@ -287,8 +290,8 @@ export class XProvider extends SocialAbstract implements SocialProvider {
   ): Promise<PostResponse[]> {
     const [accessTokenSplit, accessSecretSplit] = accessToken.split(':');
     const client = new TwitterApi({
-      appKey: process.env.X_API_KEY!,
-      appSecret: process.env.X_API_SECRET!,
+      appKey: API_KEY!,
+      appSecret: API_SECRET!,
       accessToken: accessTokenSplit,
       accessSecret: accessSecretSplit,
     });
@@ -445,8 +448,8 @@ export class XProvider extends SocialAbstract implements SocialProvider {
 
     const [accessTokenSplit, accessSecretSplit] = accessToken.split(':');
     const client = new TwitterApi({
-      appKey: process.env.X_API_KEY!,
-      appSecret: process.env.X_API_SECRET!,
+      appKey: API_KEY!,
+      appSecret: API_SECRET!,
       accessToken: accessTokenSplit,
       accessSecret: accessSecretSplit,
     });
@@ -528,8 +531,8 @@ export class XProvider extends SocialAbstract implements SocialProvider {
   override async mention(token: string, d: { query: string }) {
     const [accessTokenSplit, accessSecretSplit] = token.split(':');
     const client = new TwitterApi({
-      appKey: process.env.X_API_KEY!,
-      appSecret: process.env.X_API_SECRET!,
+      appKey: API_KEY!,
+      appSecret: API_SECRET!,
       accessToken: accessTokenSplit,
       accessSecret: accessSecretSplit,
     });


### PR DESCRIPTION
## Summary
- allow X integration to read `TWITTER_API_KEY` and `TWITTER_API_SECRET`
- use correct frontend endpoint when connecting an X account

## Testing
- `pnpm test` *(fails: Cannot find module '@nx/jest')*

------
https://chatgpt.com/codex/tasks/task_e_688e7cd6cbd8832d98c0300fc5a01c95